### PR TITLE
Easier Error Handling

### DIFF
--- a/Jobs/Translator/Cargo.toml
+++ b/Jobs/Translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google_translator"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Eveheeero <xhve00000@gmail.com>"]
 license = "MIT"

--- a/Jobs/Translator/Cargo.toml
+++ b/Jobs/Translator/Cargo.toml
@@ -22,3 +22,4 @@ json = "0.12.4"
 log = "0.4.17"
 simplelog = "0.12.0"
 clap = { version = "4.0.18", features = ["derive"] }
+thiserror = "1.0.40"

--- a/Jobs/Translator/Cargo.toml
+++ b/Jobs/Translator/Cargo.toml
@@ -20,6 +20,5 @@ tokio = { version = "1.21.2", features = ["full"] }
 reqwest = "0.11"
 json = "0.12.4"
 log = "0.4.17"
-simplelog = "0.12.0"
 clap = { version = "4.0.18", features = ["derive"] }
 thiserror = "1.0.40"

--- a/Jobs/Translator/src/main.rs
+++ b/Jobs/Translator/src/main.rs
@@ -34,9 +34,6 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // 로거 설정
-    // let _ = simplelog::SimpleLogger::init(log::LevelFilter::Debug, simplelog::Config::default());
-
     // 인자 파싱
     let args = Args::parse();
     let output_file = args.output_file;


### PR DESCRIPTION
Previously, fallible functions returned `Result<T, String>`, and `String` does not implement `std::error::Error`

Added a `TranslateError` enum that represents most error variants. The main reason to do this is to make it easier to call functions in the crate that return a `Result<T>` within functions that return `Result<T, Box<dyn std::error::Error>>` or `anyhow::Result<T>`