### PR TITLE
Passing Input by Reference to Translation Functions

### DIFF
--- a/Jobs/Translator/Cargo.toml
+++ b/Jobs/Translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google_translator"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Eveheeero <xhve00000@gmail.com>"]
 license = "MIT"

--- a/Jobs/Translator/README.md
+++ b/Jobs/Translator/README.md
@@ -33,7 +33,7 @@ async fn test_translate_multi_lines() {
     let text = vec!["Hello, world!", "내 이름은 민수야.", "나는 20살이야."]
         .iter()
         .map(|x| x.to_string())
-        .collect();
+        .collect::<Vec<_>>();
     let input_lang = "auto";
     let output_lang = "fr";
     let result = translate(&text, input_lang, output_lang).await.unwrap();

--- a/Jobs/Translator/README.md
+++ b/Jobs/Translator/README.md
@@ -36,7 +36,7 @@ async fn test_translate_multi_lines() {
         .collect();
     let input_lang = "auto";
     let output_lang = "fr";
-    let result = translate(text, input_lang, output_lang).await.unwrap();
+    let result = translate(&text, input_lang, output_lang).await.unwrap();
     dbg!(result);
     assert!(true);
 }

--- a/Jobs/Translator/src/lib.rs
+++ b/Jobs/Translator/src/lib.rs
@@ -156,7 +156,7 @@ pub fn response_to_result(response: String) -> TranslateResult {
 //////////////////////////////////////////////////////////////////////////// */
 
 pub async fn translate<T, Y>(
-    text: Vec<String>,
+    text: &Vec<String>,
     input_lang: T,
     output_lang: Y,
 ) -> Result<TranslateResult, TranslateError>
@@ -185,7 +185,7 @@ where
 }
 
 pub async fn translate_one_line<T, Y>(
-    text: String,
+    text: &str,
     input_lang: T,
     output_lang: Y,
 ) -> Result<String, TranslateError>
@@ -193,9 +193,9 @@ where
     T: Into<InputLang>,
     Y: Into<OutputLang>,
 {
-    let text = vec![text];
+    let text = vec![text.to_string()];
 
-    let result = translate(text, input_lang, output_lang).await?;
+    let result = translate(&text, input_lang, output_lang).await?;
 
     Ok(result.output_text[0][0].clone())
 }
@@ -210,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_translate_one_line() {
-        let text = "Hello, world!".to_string();
+        let text = "Hello, world!";
         let input_lang = "en";
         let output_lang = "ko";
         let result = translate_one_line(text, input_lang, output_lang)
@@ -228,7 +228,7 @@ mod tests {
             .collect();
         let input_lang = "auto";
         let output_lang = "fr";
-        let result = translate(text, input_lang, output_lang).await.unwrap();
+        let result = translate(&text, input_lang, output_lang).await.unwrap();
         dbg!(result);
         assert!(true);
     }

--- a/Jobs/Translator/src/lib.rs
+++ b/Jobs/Translator/src/lib.rs
@@ -156,7 +156,7 @@ pub fn response_to_result(response: String) -> TranslateResult {
 //////////////////////////////////////////////////////////////////////////// */
 
 pub async fn translate<T, Y>(
-    text: &Vec<String>,
+    text: &[String],
     input_lang: T,
     output_lang: Y,
 ) -> Result<TranslateResult, TranslateError>
@@ -225,7 +225,7 @@ mod tests {
         let text = vec!["Hello, world!", "내 이름은 민수야.", "나는 20살이야."]
             .iter()
             .map(|x| x.to_string())
-            .collect();
+            .collect::<Vec<_>>();
         let input_lang = "auto";
         let output_lang = "fr";
         let result = translate(&text, input_lang, output_lang).await.unwrap();

--- a/Jobs/Translator/src/main.rs
+++ b/Jobs/Translator/src/main.rs
@@ -163,16 +163,3 @@ fn print_one_line(output_file: &Option<String>, line: &String) -> Result<(), std
     };
     Ok(())
 }
-
-#[tokio::test]
-async fn test_translate_multi_lines() {
-    let text = vec!["Hello, world!", "내 이름은 민수야.", "나는 20살이야."]
-        .iter()
-        .map(ToString::to_string)
-        .collect();
-    let input_lang = "auto";
-    let output_lang = "fr";
-    let result = translate(&text, input_lang, output_lang).await.unwrap();
-    dbg!(result);
-    assert!(true);
-}


### PR DESCRIPTION
The `translate` and `translate_one_line` functions don't have to take the input by value, they could instead take them as a reference, which would allow using the values again if needed


Although, since mode 2 (`translate -m 2`) runs async threads to translate chunks concurrently, you can't pass it a non-static reference, so I refactored the code a bit. It still works, but there might be a tiny change in performance. Nothing noticeable